### PR TITLE
feat: add private functionality for roll commands

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,8 @@
         "no-restricted-syntax": "off",
         "no-return-assign": "off",
         "radix": "off",
-        "no-plusplus": "off"
+        "no-plusplus": "off",
+        "no-console": "off",
+        "no-await-in-loop": "off"
     }
 }

--- a/src/commands/CommandContext.ts
+++ b/src/commands/CommandContext.ts
@@ -7,7 +7,9 @@ class CommandContext extends CommandContextBase {
   protected commandList: ICommandList = CommandsList;
 
   configureStrategies(): void {
-    this.strategies[CommandType.Roll] = new RollCommandContext();
+    this.strategies[CommandType.Roll] = new RollCommandContext(
+      this.discordClient
+    );
   }
 }
 

--- a/src/commands/RollCommand/RollCommandContext.ts
+++ b/src/commands/RollCommand/RollCommandContext.ts
@@ -9,11 +9,13 @@ class RollCommandContext extends CommandContextBase {
   protected commandList: ICommandList = RollCommandsList;
 
   configureStrategies(): void {
-    this.strategies[RollCommandType.RollOneDice] = new RollOneDiceStrategy();
+    this.strategies[RollCommandType.RollOneDice] = new RollOneDiceStrategy(
+      this.discordClient
+    );
     this.strategies[RollCommandType.RollMultipleDices] =
-      new RollMultipleDicesStrategy();
+      new RollMultipleDicesStrategy(this.discordClient);
     this.strategies[RollCommandType.RollMultipleDicesAndSum] =
-      new RollMultipleDicesAndSumStrategy();
+      new RollMultipleDicesAndSumStrategy(this.discordClient);
   }
 }
 

--- a/src/commands/RollCommand/RollCommandsList.ts
+++ b/src/commands/RollCommand/RollCommandsList.ts
@@ -4,15 +4,15 @@ import { ICommandList } from '../base/CommandContextBase';
 
 const RollCommandsList: ICommandList = {
   [RollCommandType.RollOneDice]: new RegExp(
-    `^(?:${Constants.DEFAULT_BOT_COMMANDS_PREFIX}){1}(?:roll){1}(?: +| +d?| +1? +d)(?<diceNumber>[2-9]{1}\\d{0,2}|1\\d{1,3})(?<additionalOperations>(?: ?[+\\-*/]\\d{1,2})+)?$`,
+    `^(?:${Constants.DEFAULT_BOT_COMMANDS_PREFIX}){1}(?:roll){1}(?: +1? ?d)(?<diceNumber>[2-9]{1}\\d{0,2}|1\\d{1,3})(?<additionalOperations>(?: ?[+\\-*/]\\d{1,2})+)? ?(?:(?<isPrivate>-p) ?(?<selfSendPrivateMessage>me)? ?(?<sendResponseTo>(?:<@!\\d+> ?){1,3}))? *$`,
     Constants.DEFAULT_COMMAND_REGEX_FLAGS
   ),
   [RollCommandType.RollMultipleDices]: new RegExp(
-    `^(?:${Constants.DEFAULT_BOT_COMMANDS_PREFIX}){1}(?:roll){1} +(?<numberOfDices>[2-9]{1}\\d{0,1}|1\\d{1}) d(?<diceNumber>[2-9]{1}\\d{0,2}|1\\d{1,3})(?<additionalOperations>(?: ?[+\\-*/]\\d{1,2})+)?$`,
+    `^(?:${Constants.DEFAULT_BOT_COMMANDS_PREFIX}){1}(?:roll){1} +(?<numberOfDices>[2-9]{1}\\d{0,1}|1\\d{1}) d(?<diceNumber>[2-9]{1}\\d{0,2}|1\\d{1,3})(?<additionalOperations>(?: ?[+\\-*/]\\d{1,2})+)? ?(?:(?<isPrivate>-p) ?(?<selfSendPrivateMessage>me)? ?(?<sendResponseTo>(?:<@!\\d+> ?){1,3}))? *$`,
     Constants.DEFAULT_COMMAND_REGEX_FLAGS
   ),
   [RollCommandType.RollMultipleDicesAndSum]: new RegExp(
-    `^(?:${Constants.DEFAULT_BOT_COMMANDS_PREFIX}){1}(?:roll){1} +(?<numberOfDices>[2-9]{1}\\d{0,1}|1\\d{1})d(?<diceNumber>[2-9]{1}\\d{0,2}|1\\d{1,3})(?<additionalOperations>(?: ?[+\\-*/]\\d{1,2})+)?$`,
+    `^(?:${Constants.DEFAULT_BOT_COMMANDS_PREFIX}){1}(?:roll){1} +(?<numberOfDices>[2-9]{1}\\d{0,1}|1\\d{1})d(?<diceNumber>[2-9]{1}\\d{0,2}|1\\d{1,3})(?<additionalOperations>(?: ?[+\\-*/]\\d{1,2})+)? ?(?:(?<isPrivate>-p) ?(?<selfSendPrivateMessage>me)? ?(?<sendResponseTo>(?:<@!\\d+> ?){1,3}))? *$`,
     Constants.DEFAULT_COMMAND_REGEX_FLAGS
   ),
 };

--- a/src/commands/base/CommandContextBase.ts
+++ b/src/commands/base/CommandContextBase.ts
@@ -1,4 +1,4 @@
-import { Message } from 'discord.js';
+import { Message, Client } from 'discord.js';
 import { ICommandStrategy } from './ICommandStrategy';
 
 interface ICommandList {
@@ -10,13 +10,16 @@ interface IStrategiesList {
 }
 
 abstract class CommandContextBase implements ICommandStrategy {
+  protected discordClient: Client;
+
   protected abstract commandList: ICommandList;
 
   protected strategies: IStrategiesList = {};
 
   protected strategy?: ICommandStrategy;
 
-  constructor() {
+  constructor(client: Client) {
+    this.discordClient = client;
     this.configureStrategies();
   }
 
@@ -29,12 +32,14 @@ abstract class CommandContextBase implements ICommandStrategy {
         return;
       }
     }
-    throw new Error('Could not find a strategy for this command.');
+    throw new Error(
+      `Could not find a strategy for this command. Command: ${command}`
+    );
   }
 
-  public execute(message: Message): void {
+  public async execute(message: Message): Promise<void> {
     this.identifyStrategy(message.content);
-    this.strategy!.execute(message);
+    await this.strategy!.execute(message);
   }
 }
 

--- a/src/commands/base/CommandStrategyBase.ts
+++ b/src/commands/base/CommandStrategyBase.ts
@@ -1,10 +1,16 @@
-import { Message } from 'discord.js';
+import { Message, Client } from 'discord.js';
 import { ICommandStrategy } from './ICommandStrategy';
 
 abstract class CommandStrategyBase implements ICommandStrategy {
+  protected discordClient: Client;
+
   protected abstract commandPattern: RegExp;
 
   protected args?: {};
+
+  public constructor(client: Client) {
+    this.discordClient = client;
+  }
 
   protected identifyCommandArgs(command: string): void {
     const args = this.commandPattern.exec(command);
@@ -15,7 +21,7 @@ abstract class CommandStrategyBase implements ICommandStrategy {
     throw new Error('Could not identify command args.');
   }
 
-  abstract execute(message: Message): void;
+  abstract execute(message: Message): Promise<void>;
 }
 
 export { CommandStrategyBase };

--- a/src/commands/base/ICommandStrategy.ts
+++ b/src/commands/base/ICommandStrategy.ts
@@ -1,7 +1,7 @@
 import { Message } from 'discord.js';
 
 interface ICommandStrategy {
-  execute(message: Message): void;
+  execute(message: Message): Promise<void>;
 }
 
 export { ICommandStrategy };

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,15 +12,15 @@ client.once('ready', () => {
   console.log('Ready!');
 });
 
-const command = new CommandContext();
+const command = new CommandContext(client);
 
-client.on('messageCreate', (message: Message) => {
+client.on('messageCreate', async (message: Message) => {
   try {
     if (message.author.id !== Constants.PEEPO_BOT_ID) {
-      command.execute(message);
+      await command.execute(message);
     }
   } catch (e) {
-    console.log(e);
+    console.warn(e);
   }
 });
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2021",
     "module": "commonjs",
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
## Description

- make ICommandStrategy 'execute' method async
- a discord client is passed now as param in the constructors of classes that implements ICommandStrategy
- roll commands now accepts an optional argument '-p [me, @user,]' that
changes the default behavior of the strategy when sending the response
message (it's only send for the users quoted in the command).

## Type of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented on my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings